### PR TITLE
Highlight comments starting with #

### DIFF
--- a/syntax/gsql.vim
+++ b/syntax/gsql.vim
@@ -40,6 +40,7 @@ syn  keyword    gsqlSpecial      false null true
 "    Comments
 syn  region     gsqlComment      start="/\*" end="\*/" contains=gsqlTodo
 syn  match      gsqlComment      "//.*$" contains=gsqlTodo
+syn  match      gsqlComment      "#.*$" contains=gsqlTodo
 
 " Variables
 syn  match      gsqlVariable     "$\w\+"


### PR DESCRIPTION
GSQL supports three types of comments:

- `# <single-line comment>`
- `/* <multi-line comment> */`
- `// <single-line comment>`

This PR adds support to the first one.